### PR TITLE
Optimize ReportMail flow and mail delivery

### DIFF
--- a/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportDefinitionsController.cs
+++ b/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportDefinitionsController.cs
@@ -57,96 +57,105 @@ public class ReportDefinitionsController : Controller
 		}
 
 		// Ψөӱe FiltersJson Z DTO]uOd ValueJson^
-		private class ReportFilterDraft
+                private class ReportFilterDraft
         {
             public string? FieldName { get; set; }
             public string? DisplayName { get; set; }
             public string? DataType { get; set; }
             public string? Operator { get; set; }
             public string? ValueJson { get; set; }    // 唯一來源
-			public string? Options { get; set; }
+                        public string? Options { get; set; }
             public int? OrderIndex { get; set; }
             public bool? IsRequired { get; set; }
             public bool? IsActive { get; set; }
         }
 
+                private bool TryParseFilterDrafts(string? filtersJson, out List<ReportFilterDraft> drafts)
+                {
+                        drafts = new List<ReportFilterDraft>();
+                        if (string.IsNullOrWhiteSpace(filtersJson))
+                                return true;
+
+                        try
+                        {
+                                drafts = JsonSerializer.Deserialize<List<ReportFilterDraft>>(filtersJson) ?? new();
+                                return true;
+                        }
+                        catch (JsonException)
+                        {
+                                const string message = "自訂篩選條件格式不正確，請確認輸入內容。";
+                                ModelState.AddModelError("FiltersJson", message);
+                                ModelState.AddModelError(string.Empty, message);
+                                return false;
+                        }
+                }
+
 		// POST: ReportMail/ReportDefinitions/Create
 		// 把 BaseKind 納入 Bind；時間戳後端自動補；FiltersJson 會展開為多筆 ReportFilter（只寫 ValueJson）
 		[HttpPost]
 		[ValidateAntiForgeryToken]
-		public async Task<IActionResult> Create(
-			[Bind("ReportDefinitionID,ReportName,Category,BaseKind,Description,IsActive,CreatedAt,UpdatedAt")]
-			ReportDefinition reportDefinition,
-			[FromForm] string? FiltersJson)
-		{
-			if (!ModelState.IsValid) return View(reportDefinition);
+                public async Task<IActionResult> Create(
+                        [Bind("ReportDefinitionID,ReportName,Category,BaseKind,Description,IsActive,CreatedAt,UpdatedAt")]
+                        ReportDefinition reportDefinition,
+                        [FromForm] string? FiltersJson)
+                {
+                        if (!ModelState.IsValid) return View(reportDefinition);
 
-			var now = DateTime.Now;
-			reportDefinition.CreatedAt = now;
-			reportDefinition.UpdatedAt = now;
-			//保證這兩個欄位標準化（去空白 + 小寫），空值給預設
-			reportDefinition.Category = (reportDefinition.Category ?? "line").Trim().ToLowerInvariant();
-			reportDefinition.BaseKind = (reportDefinition.BaseKind ?? "sales").Trim().ToLowerInvariant();
+                        if (!TryParseFilterDrafts(FiltersJson, out var drafts))
+                                return View(reportDefinition);
 
-			// （建議）新增一律啟用，避免被 Index() 過濾掉
-			reportDefinition.IsActive = true;
+                        //保證這兩個欄位標準化（去空白 + 小寫），空值給預設
+                        reportDefinition.Category = (reportDefinition.Category ?? "line").Trim().ToLowerInvariant();
+                        reportDefinition.BaseKind = (reportDefinition.BaseKind ?? "sales").Trim().ToLowerInvariant();
+
+                        // （建議）新增一律啟用，避免被 Index() 過濾掉
+                        reportDefinition.IsActive = true;
 
 
-			_context.Add(reportDefinition);
-			await _context.SaveChangesAsync(); // 先產生 ReportDefinitionID
+                        _context.Add(reportDefinition);
+                        await _context.SaveChangesAsync(); // 先產生 ReportDefinitionID
 
-			if (!string.IsNullOrWhiteSpace(FiltersJson))
-			{
-				try
-				{
-					var drafts = JsonSerializer.Deserialize<List<ReportFilterDraft>>(FiltersJson) ?? new();
-					int order = 1;
-					foreach (var d in drafts)
-					{
-						// 友善的 DisplayName 後援（若前端未給）
-						var display = (d.DisplayName ?? d.FieldName) ?? "";
-						if (string.IsNullOrWhiteSpace(display))
-						{
-							display = (d.FieldName ?? "").ToLowerInvariant() switch
-							{
-								"orderdate" => "日期區間",
-								"borrowdate" => "日期區間",
-								"categoryid" => "書籍種類",
-								"saleprice" => "單本價位",
-								"metric" => "指標",
-								"orderstatus" => "訂單狀態",
-								"orderamount" => "單筆訂單金額",
-								_ => "(未命名)"
-							};
-						}
+                        if (drafts.Count > 0)
+                        {
+                                int order = 1;
+                                foreach (var d in drafts)
+                                {
+                                        // 友善的 DisplayName 後援（若前端未給）
+                                        var display = (d.DisplayName ?? d.FieldName) ?? "";
+                                        if (string.IsNullOrWhiteSpace(display))
+                                        {
+                                                display = (d.FieldName ?? "").ToLowerInvariant() switch
+                                                {
+                                                        "orderdate" => "日期區間",
+                                                        "borrowdate" => "日期區間",
+                                                        "categoryid" => "書籍種類",
+                                                        "saleprice" => "單本價位",
+                                                        "metric" => "指標",
+                                                        "orderstatus" => "訂單狀態",
+                                                        "orderamount" => "單筆訂單金額",
+                                                        _ => "(未命名)"
+                                                };
+                                        }
 
-						_context.ReportFilters.Add(new ReportFilter
-						{
-							ReportDefinitionID = reportDefinition.ReportDefinitionID,
-							FieldName = d.FieldName ?? "",
-							DisplayName = display,
-							DataType = d.DataType ?? "text",
-							Operator = d.Operator ?? "eq",
-							ValueJson = d.ValueJson ?? "{}",   //  只寫 ValueJson
-							Options = d.Options ?? "{}",
-							OrderIndex = d.OrderIndex ?? order++,
-							IsRequired = d.IsRequired ?? false,
-							IsActive = d.IsActive ?? true,
-							CreatedAt = now,                   //  後端自動化
-							UpdatedAt = now
-						});
-					}
-					await _context.SaveChangesAsync();
-				}
-				catch (Exception ex)
-				{
-					// 解析錯誤不阻斷主要流程（必要可加 ModelState 顯示）
-					Console.WriteLine(ex);
-				}
-			}
+                                        _context.ReportFilters.Add(new ReportFilter
+                                        {
+                                                ReportDefinitionID = reportDefinition.ReportDefinitionID,
+                                                FieldName = d.FieldName ?? string.Empty,
+                                                DisplayName = display,
+                                                DataType = (d.DataType ?? "text").Trim().ToLowerInvariant(),
+                                                Operator = (d.Operator ?? "eq").Trim().ToLowerInvariant(),
+                                                ValueJson = d.ValueJson ?? "{}",   //  只寫 ValueJson
+                                                Options = d.Options ?? "{}",
+                                                OrderIndex = d.OrderIndex ?? order++,
+                                                IsRequired = d.IsRequired ?? false,
+                                                IsActive = d.IsActive ?? true
+                                        });
+                                }
+                                await _context.SaveChangesAsync();
+                        }
 
-			return RedirectToAction("Index", "Reports", new { area = "ReportMail" });
-		}
+                        return RedirectToAction("Index", "Reports", new { area = "ReportMail" });
+                }
 
 		// GET: ReportMail/ReportDefinitions/Edit/5
 		public async Task<IActionResult> Edit(int? id)
@@ -161,26 +170,27 @@ public class ReportDefinitionsController : Controller
 		// 把 BaseKind 納入 Bind，並在儲存前刷新 UpdatedAt
 		[HttpPost]
 		[ValidateAntiForgeryToken]
-		public async Task<IActionResult> Edit(int id,
-			[Bind("ReportDefinitionID,ReportName,Category,BaseKind,Description,IsActive,CreatedAt,UpdatedAt")]
-			ReportDefinition reportDefinition,
-			[FromForm] string? FiltersJson // 接收前端組好的 Filter 草稿(JSON)
-		)
-		{
-			if (id != reportDefinition.ReportDefinitionID) return NotFound();
-			if (!ModelState.IsValid) return View(reportDefinition);
-			// 保證這兩個欄位標準化（去空白 + 小寫），空值給預設
-			reportDefinition.Category = (reportDefinition.Category ?? "line").Trim().ToLowerInvariant();
-			reportDefinition.BaseKind = (reportDefinition.BaseKind ?? "sales").Trim().ToLowerInvariant();
+                public async Task<IActionResult> Edit(int id,
+                        [Bind("ReportDefinitionID,ReportName,Category,BaseKind,Description,IsActive,CreatedAt,UpdatedAt")]
+                        ReportDefinition reportDefinition,
+                        [FromForm] string? FiltersJson // 接收前端組好的 Filter 草稿(JSON)
+                )
+                {
+                        if (id != reportDefinition.ReportDefinitionID) return NotFound();
+                        if (!ModelState.IsValid) return View(reportDefinition);
+                        if (!TryParseFilterDrafts(FiltersJson, out var drafts))
+                                return View(reportDefinition);
+                        // 保證這兩個欄位標準化（去空白 + 小寫），空值給預設
+                        reportDefinition.Category = (reportDefinition.Category ?? "line").Trim().ToLowerInvariant();
+                        reportDefinition.BaseKind = (reportDefinition.BaseKind ?? "sales").Trim().ToLowerInvariant();
 
-			// 一律啟用，避免被 Index() 過濾掉
-			reportDefinition.IsActive = true;
-			reportDefinition.UpdatedAt = DateTime.Now;// 後端自動刷新
+                        // 一律啟用，避免被 Index() 過濾掉
+                        reportDefinition.IsActive = true;
 
-			using var tx = await _context.Database.BeginTransactionAsync();
-			try
-			{   // 1) 先更新 Definition 本體
-				_context.Update(reportDefinition);
+                        using var tx = await _context.Database.BeginTransactionAsync();
+                        try
+                        {   // 1) 先更新 Definition 本體
+                                _context.Update(reportDefinition);
 				await _context.SaveChangesAsync();
 
 				// 2)砍掉舊的Filters(最簡潔、避免比對順序異動)
@@ -189,32 +199,29 @@ public class ReportDefinitionsController : Controller
 				await _context.SaveChangesAsync();
 
 				// 3)還原新增十的「草稿解析」:逐筆加入新的Filters
-				if (!string.IsNullOrWhiteSpace(FiltersJson))
-				{
-					var drafts = System.Text.Json.JsonSerializer.Deserialize<List<ReportFilterDraft>>(FiltersJson) ?? new();
-					var now = DateTime.Now;
-					int order = 1;
-					foreach (var d in drafts)
-					{
-						if (string.IsNullOrWhiteSpace(d.FieldName)) continue;
-						var f = new ReportFilter
-						{
-							ReportDefinitionID = reportDefinition.ReportDefinitionID,
-							FieldName = d.FieldName!.Trim(),
-							DisplayName = string.IsNullOrWhiteSpace(d.DisplayName) ? d.FieldName!.Trim() : d.DisplayName!.Trim(),
-							DataType = (d.DataType ?? "text").Trim().ToLowerInvariant(),
-							Operator = (d.Operator ?? "eq").Trim().ToLowerInvariant(),
-							ValueJson = d.ValueJson ?? "{}",   // 新版只用 ValueJson
-							Options = d.Options,
-							OrderIndex = order++,
-							IsRequired = d.IsRequired ?? false,   // 或 d.IsRequired.GetValueOrDefault(false)                            IsActive = true,
-							CreatedAt = now,
-							UpdatedAt = now
-						};
-						_context.ReportFilters.Add(f);
-					}
-					await _context.SaveChangesAsync();
-				}
+                                if (drafts.Count > 0)
+                                {
+                                        int order = 1;
+                                        foreach (var d in drafts)
+                                        {
+                                                if (string.IsNullOrWhiteSpace(d.FieldName)) continue;
+                                                var f = new ReportFilter
+                                                {
+                                                        ReportDefinitionID = reportDefinition.ReportDefinitionID,
+                                                        FieldName = d.FieldName!.Trim(),
+                                                        DisplayName = string.IsNullOrWhiteSpace(d.DisplayName) ? d.FieldName!.Trim() : d.DisplayName!.Trim(),
+                                                        DataType = (d.DataType ?? "text").Trim().ToLowerInvariant(),
+                                                        Operator = (d.Operator ?? "eq").Trim().ToLowerInvariant(),
+                                                        ValueJson = d.ValueJson ?? "{}",   // 新版只用 ValueJson
+                                                        Options = d.Options ?? "{}",
+                                                        OrderIndex = order++,
+                                                        IsRequired = d.IsRequired ?? false,   // 或 d.IsRequired.GetValueOrDefault(false)
+                                                        IsActive = true
+                                                };
+                                                _context.ReportFilters.Add(f);
+                                        }
+                                        await _context.SaveChangesAsync();
+                                }
 				await tx.CommitAsync();
 				return RedirectToAction("Index", "Reports", new { area = "ReportMail" });
 			}

--- a/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportExportController.cs
+++ b/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportExportController.cs
@@ -79,16 +79,17 @@ namespace ReportMail.Areas.ReportMail.Controllers
                     <p style=""margin-top:12px"">請查收附件。</p>
                 </div>";
 
-			_mail.SendReport(
-				to: dto.To,
-				subject: subject,
-				body: body,
-				attachmentName: safeName,
-				attachmentBytes: bytes,
-				contentType: string.IsNullOrWhiteSpace(contentType)
-					? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-					: contentType
-			);
+                        await _mail.SendReportAsync(
+                                to: dto.To,
+                                subject: subject,
+                                body: body,
+                                attachmentName: safeName,
+                                attachmentBytes: bytes,
+                                contentType: string.IsNullOrWhiteSpace(contentType)
+                                        ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                                        : contentType,
+                                cancellationToken: HttpContext.RequestAborted
+                        );
 
 			return Ok(new { message = "已寄出", to = dto.To, file = safeName });
 		}

--- a/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportsController.cs
+++ b/BookLoop/BookLoop/Areas/ReportMail/Controllers/ReportsController.cs
@@ -4,6 +4,7 @@ using BookLoop.Services.Reports;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -40,29 +41,26 @@ namespace ReportMail.Areas.ReportMail.Controllers
 		[HttpGet]
 		// 也讓 /ReportMail/Reports 直接進到這頁（不用寫 /Index）
 		[Route("/ReportMail/Reports")]
-		public async Task<IActionResult> Index()
-		{
-			var defs = _db.ReportDefinitions
-						  .AsNoTracking()
-						  .Where(r => r.IsActive);
+                public async Task<IActionResult> Index()
+                {
+                        var activeDefinitions = await _db.ReportDefinitions
+                                .AsNoTracking()
+                                .Where(r => r.IsActive)
+                                .ToListAsync();
 
-			ViewBag.LineReports = await defs
-				.Where(r => r.Category != null && r.Category.ToLower() == "line")
-				.OrderBy(r => r.ReportName)
-				.ToListAsync();
+                        static List<ReportDefinition> FilterByCategory(IEnumerable<ReportDefinition> source, string category)
+                                => source
+                                        .Where(r => !string.IsNullOrWhiteSpace(r.Category)
+                                                && string.Equals(r.Category.Trim(), category, StringComparison.OrdinalIgnoreCase))
+                                        .OrderBy(r => r.ReportName)
+                                        .ToList();
 
-			ViewBag.BarReports = await defs
-				.Where(r => r.Category != null && r.Category.ToLower() == "bar")
-				.OrderBy(r => r.ReportName)
-				.ToListAsync();
+                        ViewBag.LineReports = FilterByCategory(activeDefinitions, "line");
+                        ViewBag.BarReports = FilterByCategory(activeDefinitions, "bar");
+                        ViewBag.PieReports = FilterByCategory(activeDefinitions, "pie");
 
-			ViewBag.PieReports = await defs
-				.Where(r => r.Category != null && r.Category.ToLower() == "pie")
-				.OrderBy(r => r.ReportName)
-				.ToListAsync();
-
-			return View();
-		}
+                        return View();
+                }
 
 		/// <summary>
 		/// 折線圖：總銷售金額序列。

--- a/BookLoop/BookLoop/Areas/ReportMail/Views/ReportDefinitions/Create.cshtml
+++ b/BookLoop/BookLoop/Areas/ReportMail/Views/ReportDefinitions/Create.cshtml
@@ -230,6 +230,7 @@
                     <!-- 後端接收 -->
                     <input type="hidden" asp-for="IsActive" value="true" />
                     <input type="hidden" id="FiltersJson" name="FiltersJson" />
+                    <span class="text-danger" data-valmsg-for="FiltersJson" data-valmsg-replace="true"></span>
 
 
                 </form>

--- a/BookLoop/BookLoop/Areas/ReportMail/Views/ReportDefinitions/Edit.cshtml
+++ b/BookLoop/BookLoop/Areas/ReportMail/Views/ReportDefinitions/Edit.cshtml
@@ -1,7 +1,7 @@
 @using BookLoop.Models
 @model ReportDefinition
 @{
-    ViewData["Title"] = "½s¿è³øªí";
+    ViewData["Title"] = "ç·¨è¼¯å ±è¡¨";
     Layout = "~/Views/Shared/_Layout.cshtml";
 
     var previewUrl = Url.Action("PreviewDraft", "ReportPreview", new { area = "ReportMail" }) ?? "#";
@@ -10,9 +10,9 @@
 }
 
 <div class="d-flex align-items-center mb-3 mt-4">
-    <h1 class="h3 mb-0">½s¿è³øªí</h1>
+    <h1 class="h3 mb-0">ç·¨è¼¯å ±è¡¨</h1>
     <a href="@Url.Action("Index", "Reports", new { area = "ReportMail" })"
-       class="btn btn-outline-secondary btn-sm px-3 py-1 rounded-1 ms-2">ªð¦^</a>
+       class="btn btn-outline-secondary btn-sm px-3 py-1 rounded-1 ms-2">è¿”å›ž</a>
 </div>
 
 
@@ -26,16 +26,16 @@
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <input type="hidden" asp-for="ReportDefinitionID" />
 
-                    <!-- °ò¥»Äæ¦ì -->
+                    <!-- åŸºæœ¬æ¬„ä½ -->
                     <div class="mb-3">
-                        <label asp-for="ReportName" class="form-label">³øªí¦WºÙ</label>
+                        <label asp-for="ReportName" class="form-label">å ±è¡¨åç¨±</label>
 
-                        <!-- ¿é¤J®Ø + Àx¦s«ö¶s¨Ã±Æ -->
+                        <!-- è¼¸å…¥æ¡† + å„²å­˜æŒ‰éˆ•ä¸¦æŽ’ -->
                         <div class="input-group">
                             <input asp-for="ReportName" class="form-control" />
                             <button type="submit" id="btnSubmit"
                                     class="btn btn-primary btn-sm px-3 py-2 rounded-1">
-                                §ó·s
+                                æ›´æ–°
                             </button>
                         </div>
 
@@ -44,139 +44,140 @@
 
 
                     <div class="mb-3">
-                        <label asp-for="Category" class="form-label">¹ÏªíºØÃþ</label>
+                        <label asp-for="Category" class="form-label">åœ–è¡¨ç¨®é¡ž</label>
                         <select asp-for="Category" id="Category" class="form-select">
-                            <option value="line">§é½u¹Ï</option>
-                            <option value="bar">ªø±ø¹Ï</option>
-                            <option value="pie">¶ê»æ¹Ï</option>
+                            <option value="line">æŠ˜ç·šåœ–</option>
+                            <option value="bar">é•·æ¢åœ–</option>
+                            <option value="pie">åœ“é¤…åœ–</option>
                         </select>
                         <span asp-validation-for="Category" class="text-danger"></span>
                     </div>
 
                     <div class="mb-3">
-                        <label asp-for="BaseKind" class="form-label">°òÂ¦³øªí</label>
+                        <label asp-for="BaseKind" class="form-label">åŸºç¤Žå ±è¡¨</label>
                         <select asp-for="BaseKind" id="baseKind" class="form-select">
-                            <option value="sales">®ÑÄy¾P°â¶q¡]¥»¡^</option>
-                            <option value="borrow">®ÑÄy­É¾\¶q¡]¥»¡^</option>
-                            <option value="orders">­q³æ¡]¶È§é½u¹Ï¡^</option>
+                            <option value="sales">æ›¸ç±éŠ·å”®é‡ï¼ˆæœ¬ï¼‰</option>
+                            <option value="borrow">æ›¸ç±å€Ÿé–±é‡ï¼ˆæœ¬ï¼‰</option>
+                            <option value="orders">è¨‚å–®ï¼ˆåƒ…æŠ˜ç·šåœ–ï¼‰</option>
                         </select>
                         <span asp-validation-for="BaseKind" class="text-danger"></span>
                     </div>
 
                     <hr />
 
-                    <!-- ¤é´Á»P²É«× -->
-                    <div id="dateLabel" class="mb-2 fw-bold">¤é´Á°Ï¶¡»P²É«×</div>
+                    <!-- æ—¥æœŸèˆ‡ç²’åº¦ -->
+                    <div id="dateLabel" class="mb-2 fw-bold">æ—¥æœŸå€é–“èˆ‡ç²’åº¦</div>
                     <div class="row g-2 align-items-end mb-3">
-                        <div class="col"><label class="form-label">°_</label><input type="date" id="dateFrom" class="form-control" /></div>
-                        <div class="col"><label class="form-label">¨´</label><input type="date" id="dateTo" class="form-control" /></div>
+                        <div class="col"><label class="form-label">èµ·</label><input type="date" id="dateFrom" class="form-control" /></div>
+                        <div class="col"><label class="form-label">è¿„</label><input type="date" id="dateTo" class="form-control" /></div>
                         <div id="granGroup" class="col-auto">
-                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gDay" value="day" checked><label class="form-check-label" for="gDay">¤é</label></div>
-                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gMonth" value="month"><label class="form-check-label" for="gMonth">¤ë</label></div>
-                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gYear" value="year"><label class="form-check-label" for="gYear">¦~</label></div>
+                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gDay" value="day" checked><label class="form-check-label" for="gDay">æ—¥</label></div>
+                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gMonth" value="month"><label class="form-check-label" for="gMonth">æœˆ</label></div>
+                            <div class="form-check"><input class="form-check-input" type="radio" name="gran" id="gYear" value="year"><label class="form-check-label" for="gYear">å¹´</label></div>
                         </div>
                     </div>
 
                     <!-- sales -->
                     <div id="section-sales" class="border rounded p-3 mb-3" style="display:none">
-                        <div class="mb-2 fw-bold">¾P°â¿z¿ï</div>
+                        <div class="mb-2 fw-bold">éŠ·å”®ç¯©é¸</div>
 
                         <div class="mb-3">
-                            <label class="form-label">®ÑÄyºØÃþ</label>
+                            <label class="form-label">æ›¸ç±ç¨®é¡ž</label>
                             <select id="salesCategories" class="form-select" multiple></select>
-                            @* <div class="form-text">¿ï¡u¡]¥þ³¡¡^¡v©Î¤£¿ï¡×¥þ³¡</div> *@
+                            @* <div class="form-text">é¸ã€Œï¼ˆå…¨éƒ¨ï¼‰ã€æˆ–ä¸é¸ï¼å…¨éƒ¨</div> *@
                         </div>
 
                         <div class="row g-2 align-items-end mb-3" id="rank-sales" style="display:none">
                             <div class="col-6">
-                                <label class="form-label">¾P°â±Æ¦æ¡G°_</label>
+                                <label class="form-label">éŠ·å”®æŽ’è¡Œï¼šèµ·</label>
                                 <select id="rankFrom" class="form-select"></select>
                             </div>
                             <div class="col-6">
-                                <label class="form-label">¾P°â±Æ¦æ¡G¨´</label>
+                                <label class="form-label">éŠ·å”®æŽ’è¡Œï¼šè¿„</label>
                                 <select id="rankTo" class="form-select"></select>
                             </div>
-                            <div class="form-text">¹w³] 1~10 ¦W¡C</div>
+                            <div class="form-text">é è¨­ 1~10 åã€‚</div>
                         </div>
 
                         <div class="mb-3">
-                            <label class="form-label">³æ¥»»ù¦ì</label>
+                            <label class="form-label">å–®æœ¬åƒ¹ä½</label>
                             <select id="priceRange" class="form-select"></select>
-                            <div class="form-text">¨C 100 ¤¸¤@°Ï¶¡¡]1~1000¡^</div>
+                            <div class="form-text">æ¯ 100 å…ƒä¸€å€é–“ï¼ˆ1~1000ï¼‰</div>
                         </div>
                     </div>
 
                     <!-- borrow -->
                     <div id="section-borrow" class="border rounded p-3 mb-3" style="display:none">
-                        <div class="mb-2 fw-bold">­É¾\¿z¿ï</div>
+                        <div class="mb-2 fw-bold">å€Ÿé–±ç¯©é¸</div>
 
                         <div class="mb-3">
-                            <label class="form-label">®ÑÄyºØÃþ</label>
+                            <label class="form-label">æ›¸ç±ç¨®é¡ž</label>
                             <select id="borrowCategories" class="form-select" multiple></select>
-                            @* <div class="form-text">¿ï¡u¡]¥þ³¡¡^¡v©Î¤£¿ï¡×¥þ³¡</div> *@
+                            @* <div class="form-text">é¸ã€Œï¼ˆå…¨éƒ¨ï¼‰ã€æˆ–ä¸é¸ï¼å…¨éƒ¨</div> *@
                         </div>
 
                         <div class="row g-2 align-items-end mb-3" id="rank-borrow" style="display:none">
                             <div class="col-6">
-                                <label class="form-label">­É¾\±Æ¦æ¡G°_</label>
+                                <label class="form-label">å€Ÿé–±æŽ’è¡Œï¼šèµ·</label>
                                 <select id="rankFromBorrow" class="form-select"></select>
                             </div>
                             <div class="col-6">
-                                <label class="form-label">­É¾\±Æ¦æ¡G¨´</label>
+                                <label class="form-label">å€Ÿé–±æŽ’è¡Œï¼šè¿„</label>
                                 <select id="rankToBorrow" class="form-select"></select>
                             </div>
-                            <div class="form-text">¹w³] 1~10 ¦W¡C</div>
+                            <div class="form-text">é è¨­ 1~10 åã€‚</div>
                         </div>
-                        <!-- ¥Xª©¦~¥÷¡]¤Q¦~°Ï¶¡¡^¡G¹w³]ÁôÂÃ -->
+                        <!-- å‡ºç‰ˆå¹´ä»½ï¼ˆåå¹´å€é–“ï¼‰ï¼šé è¨­éš±è— -->
                         <div id="publishDecadeRow" class="mb-3" style="display:none">
-                            <label class="form-label">¥Xª©¦~¥÷¡]¤Q¦~°Ï¶¡¡^</label>
+                            <label class="form-label">å‡ºç‰ˆå¹´ä»½ï¼ˆåå¹´å€é–“ï¼‰</label>
                             <select id="publishDecade" class="form-select"></select>
-                            <div class="form-text">¨C 10 ¦~¤@°Ï¡A1901 ¦~°_¦Ü²{¦b¡C</div>
+                            <div class="form-text">æ¯ 10 å¹´ä¸€å€ï¼Œ1901 å¹´èµ·è‡³ç¾åœ¨ã€‚</div>
                         </div>
                     </div>
 
-                    <!-- orders¡]¶È§é½u¹Ï¡^ -->
+                    <!-- ordersï¼ˆåƒ…æŠ˜ç·šåœ–ï¼‰ -->
                     <div id="section-orders" class="border rounded p-3 mb-3" style="display:none">
-                        <div class="mb-2 fw-bold">­q³æ¿z¿ï¡]¶È§é½u¹Ï¡^</div>
+                        <div class="mb-2 fw-bold">è¨‚å–®ç¯©é¸ï¼ˆåƒ…æŠ˜ç·šåœ–ï¼‰</div>
                         <div class="mb-3">
-                            <label class="form-label d-block">«ü¼Ð</label>
-                            <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="metric" id="mAmount" value="amount"><label class="form-check-label" for="mAmount">Á`ª÷ÃB</label></div>
-                            <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="metric" id="mCount" value="count"><label class="form-check-label" for="mCount">µ§¼Æ</label></div>
+                            <label class="form-label d-block">æŒ‡æ¨™</label>
+                            <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="metric" id="mAmount" value="amount"><label class="form-check-label" for="mAmount">ç¸½é‡‘é¡</label></div>
+                            <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="metric" id="mCount" value="count"><label class="form-check-label" for="mCount">ç­†æ•¸</label></div>
                         </div>
-                        <!-- ­q³æª¬ºA¡]¥]§t¦¡¿z¿ï¡F¥þ¿ï¡×¤£°e±ø¥ó¡F¥þ¤£¤Ä¡×ªÅ¶°¦X¡^ -->
+                        <!-- è¨‚å–®ç‹€æ…‹ï¼ˆåŒ…å«å¼ç¯©é¸ï¼›å…¨é¸ï¼ä¸é€æ¢ä»¶ï¼›å…¨ä¸å‹¾ï¼ç©ºé›†åˆï¼‰ -->
                         <div class="mb-3">
-                            <label class="form-label">­q³æª¬ºA</label>
+                            <label class="form-label">è¨‚å–®ç‹€æ…‹</label>
                             <div id="orderStatusGroup" class="d-flex flex-wrap gap-3">
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="os_all">
-                                    <label class="form-check-label" for="os_all">¥þ¿ï</label>
+                                    <label class="form-check-label" for="os_all">å…¨é¸</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input os" type="checkbox" id="os_0" data-val="0">
-                                    <label class="form-check-label" for="os_0">«Ý³B²z</label>
+                                    <label class="form-check-label" for="os_0">å¾…è™•ç†</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input os" type="checkbox" id="os_1" data-val="1">
-                                    <label class="form-check-label" for="os_1">¤w¥I´Ú</label>
+                    <span class="text-danger" data-valmsg-for="FiltersJson" data-valmsg-replace="true"></span>
+                                    <label class="form-check-label" for="os_1">å·²ä»˜æ¬¾</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input os" type="checkbox" id="os_2" data-val="2">
-                                    <label class="form-check-label" for="os_2">¤w¥X³f</label>
+                                    <label class="form-check-label" for="os_2">å·²å‡ºè²¨</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input os" type="checkbox" id="os_3" data-val="3">
-                                    <label class="form-check-label" for="os_3">¤w§¹¦¨</label>
+                                    <label class="form-check-label" for="os_3">å·²å®Œæˆ</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input os" type="checkbox" id="os_4" data-val="4">
-                                    <label class="form-check-label" for="os_4">¤w¨ú®ø</label>
+                                    <label class="form-check-label" for="os_4">å·²å–æ¶ˆ</label>
                                 </div>
                             </div>
-                            @* <div class="form-text">¹w³]¥u¤Ä¡u¤w§¹¦¨¡v¡C¥þ¿ï¡×¤£¥[ª¬ºA±ø¥ó¡F¥þ¤£¤Ä¡×°eªÅ¶°¦X¡]¦^ªÅµ²ªG¡^¡C</div> *@
+                            @* <div class="form-text">é è¨­åªå‹¾ã€Œå·²å®Œæˆã€ã€‚å…¨é¸ï¼ä¸åŠ ç‹€æ…‹æ¢ä»¶ï¼›å…¨ä¸å‹¾ï¼é€ç©ºé›†åˆï¼ˆå›žç©ºçµæžœï¼‰ã€‚</div> *@
                         </div>
                         <div class="row g-2">
-                            <div class="col"><label class="form-label">³æµ§ª÷ÃB¡]Min¡^</label><input type="number" id="ordAmtMin" class="form-control" placeholder="0" /></div>
-                            <div class="col"><label class="form-label">³æµ§ª÷ÃB¡]Max¡^</label><input type="number" id="ordAmtMax" class="form-control" placeholder="999999" /></div>
+                            <div class="col"><label class="form-label">å–®ç­†é‡‘é¡ï¼ˆMinï¼‰</label><input type="number" id="ordAmtMin" class="form-control" placeholder="0" /></div>
+                            <div class="col"><label class="form-label">å–®ç­†é‡‘é¡ï¼ˆMaxï¼‰</label><input type="number" id="ordAmtMax" class="form-control" placeholder="999999" /></div>
                         </div>
                     </div>
 
@@ -191,7 +192,7 @@
     <div class="col-lg-6">
         <div class="card">
             <div class="card-body">
-                <h5 class="card-title mb-3">¹wÄý</h5>
+                <h5 class="card-title mb-3">é è¦½</h5>
                 <canvas id="previewChart" height="200"></canvas>
             </div>
         </div>
@@ -201,15 +202,15 @@
 @section Scripts {
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        window.__API_PREVIEW__ = "@previewUrl";  // §A­¶­±¤W­ì¥»ªº previewUrl ÅÜ¼Æ
-        window.__API_CATS__    = "@catsUrl";     // ¤ÀÃþ²M³æ API
-        // ¥u¦³ Edit ­¶¤~»Ý­n³o¦æ¡]Create ¤£­n©ñ¡^
+        window.__API_PREVIEW__ = "@previewUrl";  // ä½ é é¢ä¸ŠåŽŸæœ¬çš„ previewUrl è®Šæ•¸
+        window.__API_CATS__    = "@catsUrl";     // åˆ†é¡žæ¸…å–® API
+        // åªæœ‰ Edit é æ‰éœ€è¦é€™è¡Œï¼ˆCreate ä¸è¦æ”¾ï¼‰
         window.__DEF_URL__     = "@defUrl";
     </script>
 
     <script src="~/js/report-def-form.js" asp-append-version="true"></script>
     <script>
-        // ½s¿è­¶­±±M¥Î¡G§â«áºÝ©w¸q®M¦^¡]¥]§t bar/pie¡^
+        // ç·¨è¼¯é é¢å°ˆç”¨ï¼šæŠŠå¾Œç«¯å®šç¾©å¥—å›žï¼ˆåŒ…å« bar/pieï¼‰
         window.__DEF_URL__ = "@defUrl";
     </script>
     @{

--- a/BookLoop/BookLoop/Services/MailService.cs
+++ b/BookLoop/BookLoop/Services/MailService.cs
@@ -1,68 +1,72 @@
-﻿using MailKit.Net.Smtp;
+
+using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BookLoop.Services
 {
-	public class MailService
-	{
-		private readonly IConfiguration _config;
-		public MailService(IConfiguration config) => _config = config;
+        public class MailService
+        {
+                private readonly IConfiguration _config;
+                public MailService(IConfiguration config) => _config = config;
 
-		/// <summary>
-		/// 寄送一般通知（無附件）
-		/// </summary>
-		public void SendReport(string to, string subject, string body)
-		{
-			SendReport(to, subject, body, null, null);
-		}
+                /// <summary>
+                /// 寄送一般通知（無附件）
+                /// </summary>
+                public Task SendReportAsync(string to, string subject, string body, CancellationToken cancellationToken = default)
+                {
+                        return SendReportAsync(to, subject, body, null, null, cancellationToken: cancellationToken);
+                }
 
-		/// <summary>
-		/// 寄送郵件，可附加 Excel 等附件
-		/// </summary>
-		public void SendReport(string to, string subject, string body,
-							   string? attachmentName, byte[]? attachmentBytes,
-							   string contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-		{
-			var smtp = _config.GetSection("Smtp");
+                /// <summary>
+                /// 寄送郵件，可附加 Excel 等附件
+                /// </summary>
+                public async Task SendReportAsync(string to, string subject, string body,
+                                                       string? attachmentName, byte[]? attachmentBytes,
+                                                       string contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                                                       CancellationToken cancellationToken = default)
+                {
+                        var smtp = _config.GetSection("Smtp");
 
-			var host = smtp["Host"] ?? "smtp-relay.brevo.com";
-			var port = int.Parse(smtp["Port"] ?? "587");
-			var user = (smtp["UserName"] ?? "").Trim();   // Brevo Login (xxx@smtp-brevo.com)
-			var pass = (smtp["Password"] ?? "").Trim();   // Brevo SMTP Key
-			var fromEmail = (smtp["FromEmail"] ?? "").Trim(); // 已驗證的寄件位址
-			var fromName = (smtp["FromName"] ?? "Report Mailer").Trim();
+                        var host = smtp["Host"] ?? "smtp-relay.brevo.com";
+                        var port = int.Parse(smtp["Port"] ?? "587");
+                        var user = (smtp["UserName"] ?? "").Trim();   // Brevo Login (xxx@smtp-brevo.com)
+                        var pass = (smtp["Password"] ?? "").Trim();   // Brevo SMTP Key
+                        var fromEmail = (smtp["FromEmail"] ?? "").Trim(); // 已驗證的寄件位址
+                        var fromName = (smtp["FromName"] ?? "Report Mailer").Trim();
 
-			if (fromEmail.EndsWith("@smtp-brevo.com", StringComparison.OrdinalIgnoreCase))
-				throw new InvalidOperationException("FromEmail 不能是 @smtp-brevo.com，請改為 Brevo 後台已驗證的寄件位址。");
+                        if (fromEmail.EndsWith("@smtp-brevo.com", StringComparison.OrdinalIgnoreCase))
+                                throw new InvalidOperationException("FromEmail 不能是 @smtp-brevo.com，請改為 Brevo 後台已驗證的寄件位址。");
 
-			var msg = new MimeMessage();
-			msg.From.Add(new MailboxAddress(fromName, fromEmail));
-			msg.To.Add(MailboxAddress.Parse(to));
-			msg.Subject = subject;
+                        var msg = new MimeMessage();
+                        msg.From.Add(new MailboxAddress(fromName, fromEmail));
+                        msg.To.Add(MailboxAddress.Parse(to));
+                        msg.Subject = subject;
 
-			var builder = new BodyBuilder { HtmlBody = body };
-			if (attachmentBytes is { Length: > 0 })
-			{
-				builder.Attachments.Add(
-					string.IsNullOrWhiteSpace(attachmentName) ? "report.xlsx" : attachmentName,
-					attachmentBytes,
-					ContentType.Parse(contentType)
-				);
-			}
-			msg.Body = builder.ToMessageBody();
+                        var builder = new BodyBuilder { HtmlBody = body };
+                        if (attachmentBytes is { Length: > 0 })
+                        {
+                                builder.Attachments.Add(
+                                        string.IsNullOrWhiteSpace(attachmentName) ? "report.xlsx" : attachmentName,
+                                        attachmentBytes,
+                                        ContentType.Parse(contentType)
+                                );
+                        }
+                        msg.Body = builder.ToMessageBody();
 
-			using var client = new SmtpClient();
+                        using var client = new SmtpClient();
 
-			var options = (port == 465) ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTls;
-			client.Connect(host, port, options);
+                        var options = (port == 465) ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTls;
+                        await client.ConnectAsync(host, port, options, cancellationToken);
 
-			// 防止 MailKit 嘗試 XOAUTH2 → Brevo 不支援
-			client.AuthenticationMechanisms.Remove("XOAUTH2");
+                        // 防止 MailKit 嘗試 XOAUTH2 → Brevo 不支援
+                        client.AuthenticationMechanisms.Remove("XOAUTH2");
 
-			client.Authenticate(user, pass);
-			client.Send(msg);
-			client.Disconnect(true);
-		}
-	}
+                        await client.AuthenticateAsync(user, pass, cancellationToken);
+                        await client.SendAsync(msg, cancellationToken);
+                        await client.DisconnectAsync(true, cancellationToken);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- fetch active custom reports once in ReportsController.Index and group them in-memory by chart type
- validate and normalize ReportDefinition filter payloads before saving, rely on DbContext timestamp hooks, and surface JSON errors in the form views
- convert MailService to async SMTP operations and await it from ReportExportController to avoid blocking requests

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68df8a372e48832598fa1891466281e8